### PR TITLE
updates to navigation classes

### DIFF
--- a/lib/modules/bootstrap/class.bootstrap_navwalker.inc
+++ b/lib/modules/bootstrap/class.bootstrap_navwalker.inc
@@ -37,7 +37,7 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 
 	function start_el( &$output, $item, $depth = 0, $args = array(), $id = 0 ) {
 		$indent = ( $depth ) ? str_repeat( "\t", $depth ) : '';
-
+		//var_dump($item);
 		/**
 		 * Dividers, Headers or Disabled
 	     * =============================
@@ -74,9 +74,10 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 			$output .= $indent . '<li' . $id . $value . $class_names .'>';
 
 			$atts = array();
-			$atts['title']  = ! empty( $item->title ) 	   ? $item->title 	   : '';
+			$atts['title']  = ! empty( $item->attr_title ) ? $item->attr_title : ($item->title ? $item->title : '');
 			$atts['target'] = ! empty( $item->target )     ? $item->target     : '';
 			$atts['rel']    = ! empty( $item->xfn )        ? $item->xfn        : '';
+
 
 			//If item has_children add atts to a
 			if($args->has_children) {
@@ -89,6 +90,8 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 
 			$atts = apply_filters( 'nav_menu_link_attributes', $atts, $item, $args );
 
+
+
 			$attributes = '';
 			foreach ( $atts as $attr => $value ) {
 				if ( ! empty( $value ) ) {
@@ -97,21 +100,10 @@ class wp_bootstrap_navwalker extends Walker_Nav_Menu {
 				}
 			}
 
+
 			$item_output = $args->before;
 
-			/*
-			 * Glyphicons
-			 * ===========
-			 * Since the the menu item is NOT a Divider or Header we check the see
-			 * if there is a value in the attr_title property. If the attr_title
-			 * property is NOT null we apply it as the class name for the glyphicon.
-			 */
-
-			if(! empty( $item->attr_title )){
-				$item_output .= '<a'. $attributes .'><span class="glyphicon ' . esc_attr( $item->attr_title ) . '"></span>&nbsp;';
-			} else {
-				$item_output .= '<a'. $attributes .'>';
-			}
+			$item_output .= '<a'. $attributes .'>';
 
 			$item_output .= $args->link_before . apply_filters( 'the_title', $item->title, $item->ID ) . $args->link_after;
 			$item_output .= ($args->has_children) ? ' <span class="caret"></span></a>' : '</a>';

--- a/lib/modules/bootstrap/class.navigation.inc
+++ b/lib/modules/bootstrap/class.navigation.inc
@@ -9,8 +9,6 @@
 
 class Bootstrap_Navigation {
 
-    public $nav_left = false;
-    public $nav_right = false;
     public $inverse = false;
     public $container = false;
     public $sticky_top = false;
@@ -43,11 +41,7 @@ class Bootstrap_Navigation {
                         <span class="icon-bar"></span>
                         <span class="icon-bar"></span>
                     </button>
-                    <?php
-                    if($this->nav_left == true){
-                        //echo '<a class="navbar-brand" href="'.$this->hurl.'">'.$this->blog_title.'</a>';
-                        do_action('navbar_brand');
-                    } ?>
+                    <?php do_action('navbar_brand'); ?>
                 </div>
 
                 <?php
@@ -73,9 +67,9 @@ class Bootstrap_Navigation {
                         );
                     } ?>
 
-                    <?php if($this->nav_right == true){
-                        do_action('navbar_right'); ?>
-                        <?php  } ?>
+
+                        <?php do_action('navbar_right'); ?>
+
                     </div>
                     <?php if($this->container == true){
                         echo '</div>';


### PR DESCRIPTION
REMOVED Glyphicon support, deprecated navbar_left and nabber_right
options from the nav class you can now just hook directly into the
actions.